### PR TITLE
Using more than one cluster will crash ExpVar by reusing "ClusterSql" as exported name

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -174,8 +174,8 @@ func (d Driver) Open(name string) (driver.Conn, error) {
 }
 
 // NewDriver returns an initialized Cluster driver, using upstreamDriver as backend
-func NewDriver(upstreamDriver driver.Driver) Driver {
-	m := expvar.NewMap("ClusterSql")
+func NewDriver(id string, upstreamDriver driver.Driver) Driver {
+	m := expvar.NewMap(id)
 	Time := new(expvar.String)
 	Time.Set(time.Now().String())
 	m.Set("FirstInstanciated", Time)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -65,7 +65,7 @@ func TestOpen(t *testing.T) {
 		}
 	}
 
-	d := NewDriver(mysql.MySQLDriver{})
+	d := NewDriver("ClusterSql", mysql.MySQLDriver{})
 
 	for _, ncfg := range cfg.Nodes {
 		if ncfg.Password != "" {


### PR DESCRIPTION
This patch fixes the following problem by introducing a "cluster id".

```
2015/07/24 10:16:53 Reuse of exported var name: ClusterSql
panic: Reuse of exported var name: ClusterSql
goroutine 1 [running]:
log.Panicln(0xc208031a78, 0x2, 0x2)
        /usr/local/Cellar/go/1.4.2/libexec/src/log/log.go:321 +0xb9
expvar.Publish(0x851d70, 0xa, 0x7f24b535f6a0, 0xc20910e940)
        /usr/local/Cellar/go/1.4.2/libexec/src/expvar/expvar.go:257 +0x1f4
expvar.NewMap(0x851d70, 0xa, 0xc20910df20)
        /usr/local/Cellar/go/1.4.2/libexec/src/expvar/expvar.go:287 +0xc3
github.com/benthor/clustersql.NewDriver(0x7f24b535f678, 0xfe51b0, 0x0, 0x0, 0x0, 0x0)
        /Users/benutzer/go/src/github.com/benthor/clustersql/cluster.go:178 +0x4b
[...truncated...]
```
